### PR TITLE
Replace Google Docs with Google Slides

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 ### Required changes:
 - [ ] Center the description (Line 17 in HTML file) using a single change in CSS
 - [ ] Fix JS so that when the search is executed, the search engine is not present in query
-- [ ] Add Google Drive, Google Docs and Google Sheets as a provider
+- [ ] Add Google Drive, Google Slides and Google Sheets as a provider
 
 ### Optional changes:
 - [ ] Add other search providers (GitHub, Spotify, etc)


### PR DESCRIPTION
## Checklist

### Required changes:
- [ ] Center the description (Line 17 in HTML file) using a single change in CSS
- [ ] Fix JS so that when the search is executed, the search engine is not present in query
- [ ] Add Google Drive, Google Docs and Google Sheets as a provider

### Optional changes:
- [ ] Add other search providers (GitHub, Spotify, etc)
- [ ] Additional CSS styling (as you like)